### PR TITLE
fix `Sound` skips the first three frames

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -298,7 +298,7 @@ pub struct Sound {
 
 impl Default for Sound {
     fn default() -> Self {
-        let mut sound = Self {
+        Self {
             sample_rate: 0,
             frames: Arc::new([]),
             paused: false,
@@ -310,15 +310,7 @@ impl Default for Sound {
             commands: vec![],
             loop_points: Parameter::new(LoopPoints::NO_LOOP),
             loop_enabled: false,
-        };
-
-        // fill the resampler with 3 audio frames so the playback starts
-        // immediately (the resampler needs 4 samples to output any audio)
-        for _ in 0..3 {
-            sound.update_position();
         }
-
-        sound
     }
 }
 
@@ -363,6 +355,23 @@ where
 }
 
 impl Sound {
+    /// Make a new [`Sound`] with sample_rate and frames.
+    fn new(sample_rate: u32, frames: Arc<[Frame]>) -> Self {
+        let mut sound = Sound {
+            sample_rate,
+            frames,
+            ..Default::default()
+        };
+
+        // fill the resampler with 3 audio frames so the playback starts
+        // immediately (the resampler needs 4 samples to output any audio)
+        for _ in 0..3 {
+            sound.update_position();
+        }
+
+        sound
+    }
+
     /// Make a [`Sound`] from [`symphonia`]'s [`Box`]'ed [`MediaSource`].
     ///
     /// Required features: `symphonia`
@@ -435,11 +444,7 @@ impl Sound {
             frames.append(&mut load_frames_from_buffer_ref(&buffer)?);
         }
 
-        Ok(Self {
-            sample_rate,
-            frames: frames.into(),
-            ..Default::default()
-        })
+        Ok(Self::new(sample_rate, frames.into()))
     }
 
     /// Make a [`Sound`] from [`symphonia`]'s [`MediaSource`].
@@ -483,11 +488,7 @@ impl Sound {
     /// Make a [`Sound`] from a slice of [`Frame`]s and a sample rate.
     #[inline]
     pub fn from_frames(sample_rate: u32, frames: &[Frame]) -> Self {
-        Self {
-            sample_rate,
-            frames: frames.into(),
-            ..Default::default()
-        }
+        Self::new(sample_rate, frames.into())
     }
 
     /// Return the sample rate of the sound.


### PR DESCRIPTION
Hi, I'm developing an audio visualizer, and I found this library is useful to me.
While I was reading the code of this library, I thought I found a kind of bug.

Currently, the code that filling the resampler with 3 frames is in `Default::default()`.
`Default::default()` first initializes `Sound.frames` with a empty slice.
So, `Sound::update_position` is called when `Sound.frames` is empty.
Then the resampler always gets `Frame::ZERO`, and `Sound::update_position` increment the `Sound.index` three times.
After the `Default::default()` is executed, `Sound.frames` is re-assigned by the struct initialization expression (`Self { frames: ... }`), without changing `Sound.index`.
I think this might cause the player always skips the first three frames of `Sound.frames`.

So, I made a fixed version.
`Default::default()` doesn't include any mutating codes, and a new `Sound::new` function includes it.
`Sound::new` uses `..Default::default()` to initialize the struct.
`Sound::from_*` functions call `Sound::new` to properly fill the resampler with 3 frames.

I think we can remove `Sound::new` and make `Sound::from_frames` do what `Sound::new` does.
If you think it's a better design, you can edit this PR.
(In my version, the difference between `Sound::new` and `Sound::from_frames` is that `Sound::new` is a private function and accepts `Arc<[Frame]>`, and `Sound::from_frames` is a `pub` function and accepts `&[Frame]`.)