### PR TITLE
Make it compile without cpal feature

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,7 @@ pub enum KaError {
     #[error("failed to get default track as no tracks are present")]
     NoTracksArePresent,
     #[error("failed to get cpal device name: {0}")]
+    #[cfg(feature = "cpal")]
     DeviceNameError(#[from] cpal::DeviceNameError),
 
     // [`Sound`] errors

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -11,6 +11,7 @@ pub trait Renderer: Clone + Send + 'static {
     fn next_frame(&mut self, sample_rate: u32) -> Frame;
 
     /// This gets called when an audio buffer is done processing.
+    #[cfg(feature = "cpal")]
     fn on_buffer<T>(&mut self, _buffer: &mut [T])
     where
         T: cpal::SizedSample + cpal::FromSample<f32>,
@@ -60,6 +61,7 @@ impl Renderer for DefaultRenderer {
         out
     }
 
+    #[cfg(feature = "cpal")]
     fn on_buffer<T>(&mut self, buffer: &mut [T])
     where
         T: cpal::SizedSample + cpal::FromSample<f32>,


### PR DESCRIPTION
```    
fn on_buffer<T>(&mut self, _buffer: &mut [T])
    where
        T: cpal::SizedSample + cpal::FromSample<f32>,
```

trait method depends on cpal crate types.
Disable on_buffer trait method for builds without cpal feature enabled