### PR TITLE
Make RecordMixer::play method immutable

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -134,7 +134,7 @@ impl RecordMixer {
     /// Note: Cloning a [`Sound`] *does not* take any extra memory, as [`Sound`]
     /// shares frame data with all clones.
     #[inline]
-    pub fn play(&mut self, sound: impl Into<SoundHandle>) -> SoundHandle {
+    pub fn play(&self, sound: impl Into<SoundHandle>) -> SoundHandle {
         let handle: SoundHandle = sound.into();
         self.renderer.guard().add_sound(handle.clone());
         handle


### PR DESCRIPTION
It looks like play method does not need to take `&mut self`